### PR TITLE
10 add test containers

### DIFF
--- a/backend/InternalControl/pom.xml
+++ b/backend/InternalControl/pom.xml
@@ -89,6 +89,27 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/org.testcontainers/mysql -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.21.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/org.testcontainers/testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>2.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.21.4</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>me.paulschwarz</groupId>

--- a/backend/InternalControl/src/main/resources/application.properties
+++ b/backend/InternalControl/src/main/resources/application.properties
@@ -1,7 +1,6 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.flyway.enabled=false

--- a/backend/InternalControl/src/test/java/com/example/InternalControl/InternalControlApplicationTests.java
+++ b/backend/InternalControl/src/test/java/com/example/InternalControl/InternalControlApplicationTests.java
@@ -2,9 +2,32 @@ package com.example.InternalControl;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @SpringBootTest
 class InternalControlApplicationTests {
+
+  @Container
+  static MySQLContainer<?> mysql =
+          new MySQLContainer<>("mysql:8.4")
+                  .withDatabaseName("internal_control_test")
+                  .withUsername("test")
+                  .withPassword("test");
+
+  @DynamicPropertySource
+  static void configureProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", mysql::getJdbcUrl);
+    registry.add("spring.datasource.username", mysql::getUsername);
+    registry.add("spring.datasource.password", mysql::getPassword);
+    registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+  }
+
   @Test
-  void contextLoads() {}
+  void contextLoads() {
+  }
 }


### PR DESCRIPTION
This pull request updates the test infrastructure to use Testcontainers with a real MySQL database for integration testing, instead of the in-memory H2 database. It also updates configuration to support dynamic database properties, making the application more flexible and production-like in its test environment.

**Test Infrastructure Modernization:**

* Added Testcontainers dependencies (`mysql`, `testcontainers`, `junit-jupiter`) to `pom.xml` to enable running MySQL containers in integration tests.
* Updated the main test class (`InternalControlApplicationTests.java`) to use a Testcontainers-managed MySQL instance, and dynamically inject its connection properties into the Spring context.

**Configuration Changes:**

* Changed `application.properties` to use environment variables for the datasource configuration, allowing dynamic injection of database connection details.


closes #10 