### PR TITLE
fix: update Vue Router to modern syntax and nested btns

### DIFF
--- a/frontend/src/features/auth/views/LoginView.vue
+++ b/frontend/src/features/auth/views/LoginView.vue
@@ -36,30 +36,6 @@ const handleLogin = async () => {
 <template>
   <div class="login-page">
     <div class="login-container">
-      <!-- Mock-brukere info -->
-      <div class="mock-users-info">
-        <h3>Testbrukere (Mock-modus)</h3>
-        <div class="mock-user-list">
-          <div class="mock-user" @click="email = 'Tri@gmail.com'; password = 'Tri'">
-            <strong>Tri</strong> (Admin)<br>
-            <small>Tri@gmail.com / Tri</small>
-          </div>
-          <div class="mock-user" @click="email = 'kari@everest-sushi.no'; password = 'Test1234!'">
-            <strong>Kari Olsen</strong> (Admin)<br>
-            <small>kari@everest-sushi.no / Test1234!</small>
-          </div>
-          <div class="mock-user" @click="email = 'amir@everest-sushi.no'; password = 'Test1234!'">
-            <strong>Amir Patel</strong> (Manager)<br>
-            <small>amir@everest-sushi.no / Test1234!</small>
-          </div>
-          <div class="mock-user" @click="email = 'lina@everest-sushi.no'; password = 'Test1234!'">
-            <strong>Lina Nguyen</strong> (Staff)<br>
-            <small>lina@everest-sushi.no / Test1234!</small>
-          </div>
-        </div>
-        <p class="mock-hint">Klikk på en bruker for å fylle inn automatisk</p>
-      </div>
-
       <form class="login-form" @submit.prevent="handleLogin">
         <h2>Logg inn</h2>
 
@@ -287,7 +263,7 @@ const handleLogin = async () => {
   .login-form {
     padding: 24px;
   }
-  
+
   .mock-users-info {
     padding: 16px;
   }

--- a/frontend/src/layouts/NavSection.vue
+++ b/frontend/src/layouts/NavSection.vue
@@ -76,13 +76,15 @@ const getIcon = (iconName: string) => {
     :class="{ 'nav-section--active': isActive }"
   >
     <!-- Section Header -->
-    <button 
+    <div 
       class="section-header"
       :class="{ 'section-header--active': isActive }"
-      :aria-expanded="isExpanded"
-      @click="handleHeaderClick"
     >
-      <div class="section-header__content">
+      <button 
+        class="section-header__content"
+        :aria-expanded="isExpanded"
+        @click="handleHeaderClick"
+      >
         <span class="section-header__icon" v-html="getIcon(section.icon)" />
         <span class="section-header__label">{{ section.label }}</span>
         <span 
@@ -91,7 +93,7 @@ const getIcon = (iconName: string) => {
         >
           {{ section.items.reduce((acc, item) => acc + (item.badge || 0), 0) }}
         </span>
-      </div>
+      </button>
       
       <!-- Toggle button -->
       <button 
@@ -112,7 +114,7 @@ const getIcon = (iconName: string) => {
           <polyline points="6 9 12 15 18 9"></polyline>
         </svg>
       </button>
-    </button>
+    </div>
     
     <!-- Collapsible Items -->
     <transition name="collapse">
@@ -159,12 +161,22 @@ const getIcon = (iconName: string) => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
+  padding: 0;
   background: transparent;
   border: none;
   border-left: 3px solid transparent;
-  cursor: pointer;
   transition: all 0.15s ease;
+}
+
+.section-header__content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
   font-family: inherit;
   text-align: left;
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -124,7 +124,7 @@ const router = createRouter({
   ],
 })
 
-router.beforeEach(async (to, from, next) => {
+router.beforeEach(async (to, from) => {
   const authStore = useAuthStore()
   
   if (to.meta.title) {
@@ -137,25 +137,22 @@ router.beforeEach(async (to, from, next) => {
     }
     
     if (!authStore.isAuthenticated) {
-      next({ name: 'Login', query: { redirect: to.fullPath } })
-      return
+      return { name: 'Login', query: { redirect: to.fullPath } }
     }
     
     if (to.meta.allowedRoles && to.meta.allowedRoles.length > 0) {
       const userRole = authStore.user?.role
       if (!userRole || !to.meta.allowedRoles.includes(userRole)) {
-        next({ name: 'Dashboard' })
-        return
+        return { name: 'Dashboard' }
       }
     }
   }
   
   if (to.name === 'Login' && authStore.isAuthenticated) {
-    next({ name: 'Dashboard' })
-    return
+    return { name: 'Dashboard' }
   }
   
-  next()
+  // Return nothing to allow navigation
 })
 
 export default router


### PR DESCRIPTION
Fixes Vue Router deprecation warning by replacing next() with return values. Changed parent btn to div-element